### PR TITLE
Fix/search_refactor

### DIFF
--- a/src/accommodation/accommodation.service.ts
+++ b/src/accommodation/accommodation.service.ts
@@ -400,7 +400,9 @@ export class AccommodationService {
       };
     }
 
-    if (this.isInvalidDateRange(checkInDate, checkOutDate)) {
+    if (!checkInDate && !checkOutDate) return;
+
+    if (!this.isValidDateRange(checkInDate, checkOutDate)) {
       throw new BadRequestException(ErrorsTypes.BAD_REQUEST_INVALID_DATE_RANGE);
     }
 
@@ -410,13 +412,17 @@ export class AccommodationService {
     };
   }
 
-  private isInvalidDateRange(checkIn: Date | undefined, checkOut: Date | undefined) {
-    if (!checkIn || !checkOut) return true;
-    return (
+  private isValidDateRange(checkIn: Date | undefined, checkOut: Date | undefined) {
+    if (
+      !checkIn ||
+      !checkOut ||
       dayjs(checkOut).isSameOrBefore(dayjs(checkIn), 'day') ||
       dayjs(checkIn).isBefore(dayjs(), 'day') ||
       dayjs(checkOut).isSameOrBefore(dayjs(), 'day')
-    );
+    )
+      return false;
+
+    return true;
   }
 
   private makeAddressConditions(location: string) {

--- a/src/accommodation/accommodation.service.ts
+++ b/src/accommodation/accommodation.service.ts
@@ -402,7 +402,7 @@ export class AccommodationService {
 
     if (!checkInDate && !checkOutDate) return;
 
-    if (!this.isValidDateRange(checkInDate, checkOutDate)) {
+    if (!checkInDate || !checkOutDate || this.isInvalidDateRange(checkInDate, checkOutDate)) {
       throw new BadRequestException(ErrorsTypes.BAD_REQUEST_INVALID_DATE_RANGE);
     }
 
@@ -412,17 +412,12 @@ export class AccommodationService {
     };
   }
 
-  private isValidDateRange(checkIn: Date | undefined, checkOut: Date | undefined) {
-    if (
-      !checkIn ||
-      !checkOut ||
+  private isInvalidDateRange(checkIn: Date | undefined, checkOut: Date | undefined) {
+    return (
       dayjs(checkOut).isSameOrBefore(dayjs(checkIn), 'day') ||
       dayjs(checkIn).isBefore(dayjs(), 'day') ||
       dayjs(checkOut).isSameOrBefore(dayjs(), 'day')
-    )
-      return false;
-
-    return true;
+    );
   }
 
   private makeAddressConditions(location: string) {


### PR DESCRIPTION
refactored code to be like:

```
!checkIn && !checkOut => no filter for dates needed (show all accommodations);

!checkIn || !checkOut || isInvalid(checkIn && checkOut) => can`t filter => error (show no accommodations);

other cases (both and valid dates) => filter (show filtered accommodations);
```
